### PR TITLE
Add Enpass MCP server

### DIFF
--- a/packages/security/enpass-mcp.json
+++ b/packages/security/enpass-mcp.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "Enpass",
+  "packageName": "enpass-mcp",
+  "runtime": "node",
+  "binArgs": [
+    "serve"
+  ],
+  "url": "https://github.com/bitterdev/enpass-mcp",
+  "license": "MIT",
+  "author": "Fabian Bitter",
+  "description": "Reads local Enpass SQLCipher vaults: list vaults and entries, read an entry or its password, generate TOTP codes and export attachments. Read-only by default; creating and deleting entries is opt-in via ENPASS_MCP_ALLOW_WRITES. The master password is read from the OS keychain and never passes through the model.",
+  "env": {
+    "ENPASS_MCP_ALLOW_WRITES": {
+      "description": "Set to 1 to enable the writing tools (create_item, delete_item, sync_pull). Unset means read-only.",
+      "required": false
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #426, where this entry was pulled out.

The blocker there was that npm `latest` was 0.1.0, which still exposed `create_item` even though write support had been removed in the repository. That is resolved: **enpass-mcp 0.2.0 is published**, and it takes a different approach than simply deleting the feature.

Writing works and is documented, but it is now a capability switch. The server starts read-only and does not register `create_item`, `delete_item` or `sync_pull` at all unless `ENPASS_MCP_ALLOW_WRITES` is set, so a client that should not touch the vault never sees those tools. The vault corruption that motivated removing writes came from NULL columns, an incomplete template field set and a stale sync state, not from Enpass rejecting outside writes; the README explains all three rules, and the behaviour is covered by tests.

The registry entry reflects that: the description says read-only by default, and the env block documents the switch.