### PR TITLE
Add DialMCP remote phone-call MCP server

### DIFF
--- a/packages/communication/dialmcp.json
+++ b/packages/communication/dialmcp.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "DialMCP",
+  "packageName": "@toolsdk-remote/dialmcp",
+  "description": "Let AI agents place real phone calls from your SMS-verified number, with transcripts, recordings, and structured outcomes. US & Canada.",
+  "url": "https://github.com/SkillfulAgents/dialmcp-connector",
+  "readme": "https://github.com/SkillfulAgents/dialmcp-connector#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "SkillfulAgents",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.dialmcp.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Add DialMCP

Remote hosted MCP for real outbound phone calls from the user's SMS-verified number.

| Field | Value |
|---|---|
| Category | `communication` |
| Endpoint | `https://mcp.dialmcp.com/mcp` |
| Auth | OAuth 2.1 |
| Website | https://dialmcp.com |
| Connector | https://github.com/SkillfulAgents/dialmcp-connector (MIT) |
| Official registry | `com.dialmcp/dialmcp` |

Modeled after other remote `streamable-http` + `oauth2` entries (e.g. DomScan, OpenPost).
