### PR TITLE
Add Loa healthcare pricing MCP server

### DIFF
--- a/packages/data-science-tools/loa-healthcare-pricing.json
+++ b/packages/data-science-tools/loa-healthcare-pricing.json
@@ -1,0 +1,25 @@
+{
+  "type": "mcp-server",
+  "name": "Loa Healthcare Pricing",
+  "packageName": "@toolsdk-remote/io-github-aanari-loacare-healthcare-pricing",
+  "description": "Provides OAuth-authenticated U.S. healthcare price, CPT/HCPCS, provider, hospital, and provenance searches through a hosted MCP endpoint, plus reviewed provider correction submission.",
+  "url": "https://github.com/aanari/loacare-healthcare-pricing",
+  "readme": "https://www.loacare.com/mcp",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://www.loacare.com/api/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": [
+          "openid",
+          "email",
+          "profile"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the official hosted Loa Healthcare Pricing MCP endpoint as a remote data-science server.

Primary sources:
- Documentation: https://www.loacare.com/mcp
- Public metadata repository: https://github.com/aanari/loacare-healthcare-pricing
- OAuth resource metadata: https://www.loacare.com/.well-known/oauth-protected-resource
- Streamable HTTP endpoint: https://www.loacare.com/api/mcp

The endpoint initializes with MCP protocol 2025-11-25 and currently exposes 12 tools for CPT/HCPCS lookup, healthcare price estimates, provider and hospital discovery, source provenance, and reviewed entity corrections. Tool invocation requires OAuth 2.1 with the published `openid email profile` scopes; unauthenticated `tools/list` remains available for discovery.

Validation:
- `node scripts/validate-registry.mjs --base origin/main`
- `git diff --check origin/main...HEAD`
- Live unauthenticated `initialize`: PASS
- Live unauthenticated `tools/list`: PASS, 12 tools
- Live unauthenticated `search_cpt_codes` call: correctly returned an OAuth challenge matching the protected-resource metadata

The PR changes only `packages/data-science-tools/loa-healthcare-pricing.json`.