### PR TITLE
Add Brainiall TTS MCP server

### DIFF
--- a/packages/other-tools-and-integrations/brainiall-tts-mcp.json
+++ b/packages/other-tools-and-integrations/brainiall-tts-mcp.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "Brainiall TTS MCP",
+  "packageName": "@toolsdk-remote/brainiall-tts-mcp",
+  "description": "Connects to hosted text-to-speech with 54 voices across nine languages, including Brazilian Portuguese. Tool discovery and health checks work without authentication; synthesis and voice listing require a Brainiall API key configured directly in the MCP client.",
+  "url": "https://github.com/fasuizu-br/brainiall-tts-mcp",
+  "readme": "https://github.com/fasuizu-br/brainiall-tts-mcp#readme",
+  "runtime": "python",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.brainiall.com/mcp/tts/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the public Brainiall TTS Streamable HTTP MCP endpoint to the registry. The server exposes 54 voices across nine languages, including Brazilian Portuguese.

Official source and setup documentation: https://github.com/fasuizu-br/brainiall-tts-mcp

The public endpoint supports MCP initialization, tool discovery, and health checks without a credential. Speech synthesis and the voice catalog require a Brainiall API key configured directly by the MCP client; the registry entry states that limitation because this registry does not model API-key header injection for remote transports.

## Validation

- `node scripts/validate-registry.mjs --all` — 4,909 files, 0 errors, 0 warnings
- `node scripts/validate-registry.mjs --base upstream/main` — 1 changed file, 0 errors, 0 warnings
- Remote MCP `initialize` — HTTP 200, Streamable HTTP response

The PR contains only the new package JSON file.