### PR TITLE
feat(registry): add Unified AI System

### DIFF
--- a/packages/aggregators/unified-ai-system.json
+++ b/packages/aggregators/unified-ai-system.json
@@ -2,7 +2,7 @@
   "type": "mcp-server",
   "name": "Unified AI System",
   "packageName": "ghcr.io/happy520ai/unified-ai-system/mcp-server",
-  "description": "Runs a self-hosted, terminal-first AI gateway that exposes eight stdio MCP tools for health, readiness, deterministic credential-free chat, knowledge, workflow, and workforce inspection.",
+  "description": "Runs a self-hosted, terminal-first AI gateway that exposes nine stdio MCP tools for provider-free prompt enhancement, health, readiness, deterministic credential-free chat, knowledge, workflow, and workforce inspection.",
   "url": "https://github.com/happy520ai/unified-ai-system",
   "readme": "https://github.com/happy520ai/unified-ai-system/tree/master/packages/mcp-server",
   "runtime": "docker",
@@ -12,7 +12,7 @@
     "run",
     "--rm",
     "-i",
-    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.3.3"
+    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.0"
   ],
   "env": {}
 }

--- a/packages/aggregators/unified-ai-system.json
+++ b/packages/aggregators/unified-ai-system.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "Unified AI System",
+  "packageName": "ghcr.io/happy520ai/unified-ai-system/mcp-server",
+  "description": "Runs a self-hosted, terminal-first AI gateway that exposes eight stdio MCP tools for health, readiness, deterministic credential-free chat, knowledge, workflow, and workforce inspection.",
+  "url": "https://github.com/happy520ai/unified-ai-system",
+  "readme": "https://github.com/happy520ai/unified-ai-system/tree/master/packages/mcp-server",
+  "runtime": "docker",
+  "license": "Apache-2.0",
+  "author": "happy520ai",
+  "binArgs": [
+    "run",
+    "--rm",
+    "-i",
+    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.3.2"
+  ],
+  "env": {}
+}

--- a/packages/aggregators/unified-ai-system.json
+++ b/packages/aggregators/unified-ai-system.json
@@ -12,7 +12,7 @@
     "run",
     "--rm",
     "-i",
-    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.3.2"
+    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.3.3"
   ],
   "env": {}
 }

--- a/packages/aggregators/unified-ai-system.json
+++ b/packages/aggregators/unified-ai-system.json
@@ -12,7 +12,7 @@
     "run",
     "--rm",
     "-i",
-    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.0"
+    "ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8"
   ],
   "env": {}
 }


### PR DESCRIPTION
## Summary

- add Unified AI System to the Aggregators category as a Docker MCP server
- pin the public multi-architecture image at `0.4.8`
- describe the public source, MCP guide, Apache-2.0 license, credential-free default, and provider-free prompt enhancement

## Source verification

- Repository: https://github.com/happy520ai/unified-ai-system
- MCP guide: https://github.com/happy520ai/unified-ai-system/tree/master/packages/mcp-server
- Prompt enhancement: https://github.com/happy520ai/unified-ai-system/blob/master/docs/prompt-enhancement.md
- Release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.8
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.happy520ai%2Funified-ai-system/versions/0.4.8
- OCI image: `ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8` (public linux/amd64 and linux/arm64 manifests)

The default container starts an isolated local fake provider and exposes nine stdio MCP tools. `gateway_prompt_enhance` structures natural-language requests locally without calling a provider. No environment variable or real-provider call is required for the registry entry.

## Validation

- the registry entry parses as JSON
- the public `0.4.8` Docker manifest resolves
- package name, runtime, license, author, and empty environment contract remain unchanged
- current source CI, scanner, Docker build, and Pages deployment passed: https://github.com/happy520ai/unified-ai-system/actions/runs/31366769414