### PR TITLE
Add Parallel Search MCP server

### DIFF
--- a/packages/search-data-extraction/parallel-search-mcp.json
+++ b/packages/search-data-extraction/parallel-search-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "Parallel Search MCP",
+  "packageName": "@toolsdk-remote/parallel-search-mcp",
+  "description": "Provides real-time web search and clean URL content extraction through a free anonymous endpoint, with optional bearer authentication for higher limits.",
+  "url": "https://docs.parallel.ai/integrations/mcp/search-mcp",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
ToolSDK's search registry did not have a Parallel entry. This adds the public anonymous endpoint through the registry's existing remote MCP path, so users can discover `web_search` and `web_fetch` without configuring an account or API key.

## What changed

- Added one remote-server record under `packages/search-data-extraction/`.
- Used the public Streamable HTTP endpoint with no required environment variables.
- Left generated indexes, dependencies, and existing server records unchanged.

## Validation

- `node scripts/validate-registry.mjs --all` checked 4,909 records with no errors or warnings.
- All 12 trusted registry-validator tests passed.
- A credential-free MCP `initialize` and `tools/list` handshake advertised `web_search` and `web_fetch`.

I did not install or execute any submitted registry package.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.