### PR TITLE
fix(monitoring): apistatuscheck entry points at an unrunnable npm bin — switch to streamable-http remote

### DIFF
--- a/packages/monitoring/apistatuscheck-mcp-server.json
+++ b/packages/monitoring/apistatuscheck-mcp-server.json
@@ -1,10 +1,16 @@
 {
   "type": "mcp-server",
-  "packageName": "apistatuscheck-mcp-server",
-  "description": "Check real-time operational status of 114+ cloud services and APIs — AWS, GitHub, Stripe, OpenAI, Vercel, Cloudflare, and more — directly from AI assistants without leaving the chat.",
+  "packageName": "@toolsdk-remote/apistatuscheck-mcp-server",
+  "description": "Check real-time operational status of 285+ cloud services and APIs — AWS, GitHub, Stripe, OpenAI, Vercel, Cloudflare, and more — directly from AI assistants without leaving the chat.",
   "url": "https://github.com/shibley/apistatuscheck-mcp-server",
   "runtime": "node",
   "license": "MIT",
   "env": {},
-  "name": "API Status Check MCP Server"
+  "name": "API Status Check MCP Server",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://apistatuscheck.com/api/mcp"
+    }
+  ]
 }


### PR DESCRIPTION
## The bug

`packages/monitoring/apistatuscheck-mcp-server.json` provisions an npm package whose bin cannot start. Reproduction on a clean machine:

```
$ echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}' \
    | npx -y apistatuscheck-mcp-server
import: delegate library support not built-in '' (X11) @ error/import.c/ImportImageCommand/1302.
Version: ImageMagick 7.1.2-13 Q16-HDRI aarch64 ...
```

The published `apistatuscheck-mcp-server@0.1.0` tarball ships `dist/index.js` **with no `#!/usr/bin/env node` shebang** and no exec bit, so the bin gets handed to `sh`, which resolves the bundle's first line (`import { McpServer } ...`) to ImageMagick's `import(1)`. It exits **0**, so the failure looks like a server that started and then never spoke MCP.

I maintain this server. The shebang is fixed in the source repo but is **not** in the version on the npm registry, so the registry entry is broken for everyone today.

## The fix in this PR

Switch the entry to the maintained Streamable HTTP endpoint using the schema's existing `remotes` field:

```json
"remotes": [{ "type": "streamable-http", "url": "https://apistatuscheck.com/api/mcp" }]
```

Per the `REMOTE_PACKAGE_PREFIX` rule in `scripts/validate-registry.mjs`, `packageName` is renamed to `@toolsdk-remote/apistatuscheck-mcp-server`. **`node scripts/validate-registry.mjs --all` → 4908 files, 0 errors, 0 warnings.**

Verified live against the endpoint before opening this PR:

```
$ curl -s -X POST https://apistatuscheck.com/api/mcp -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
{"result":{"tools":[{"name":"list_apis", ... }]}}
```

`initialize` and `tools/list` both round-trip; also verified through `mcp-remote@0.1.37`. Read-only, no auth, no API key, so this should be able to reach `validated: true` and carry `tools` metadata in the index — which the broken npm path never could.

Also corrected the description: **114 → 285** services, read from a live `list_apis` call returning `{"total": 285, ...}`, not from the old README.

## Caveats, stated plainly

- The `packageName` rename changes this entry's registry key. That's required by your own validator for `remotes` entries, but if you'd rather keep the old key and **delete** this entry until a fixed tarball is on npm, I'll send that PR instead — I'd rather the entry be gone than error for users.
- The endpoint is POST-based Streamable HTTP with no held-open SSE stream; a bare `GET` returns 405.
- Statuses from `list_apis` come from an hourly monitor and carry a timestamp; `get_api_status` probes at call time. Single-region probe.

**Disclosure:** I'm the author of apistatuscheck.com. I'm not asking for a new listing — only for the entry already merged here (#346) to work.
