### PR TITLE
Add @michalpiszczek/ai-economics-mcp

### DIFF
--- a/packages/developer-tools/ai-economics-mcp.json
+++ b/packages/developer-tools/ai-economics-mcp.json
@@ -1,7 +1,7 @@
 {
   "type": "mcp-server",
   "packageName": "@michalpiszczek/ai-economics-mcp",
-  "description": "12 calculators for AI cost, energy and agent verification: token cost across vendors, context-window sizing, agent-hour cost (compute plus human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Backed by a keyless, stateless JSON API; every response carries the formula, an interpretation and a citable source.",
+  "description": "12 calculators for AI cost, energy and agent verification: token cost across vendors, context-window sizing, agent-hour cost (compute plus human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Backed by a keyless, stateless JSON API; every response carries the formula, an interpretation and a citable source. By Michał Piszczek — https://piszczek.pl/tools.",
   "url": "https://github.com/pich/ai-economics-mcp",
   "runtime": "node",
   "license": "MIT",

--- a/packages/developer-tools/ai-economics-mcp.json
+++ b/packages/developer-tools/ai-economics-mcp.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "@michalpiszczek/ai-economics-mcp",
+  "description": "12 calculators for AI cost, energy and agent verification: token cost across vendors, context-window sizing, agent-hour cost (compute plus human review), model-routing savings, LLM energy and CO2, joules per verified task, org-wide token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck and proof debt. Backed by a keyless, stateless JSON API; every response carries the formula, an interpretation and a citable source.",
+  "url": "https://github.com/pich/ai-economics-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "AI Economics"
+}


### PR DESCRIPTION
Adds one server: **[@michalpiszczek/ai-economics-mcp](https://www.npmjs.com/package/@michalpiszczek/ai-economics-mcp)** at `packages/developer-tools/ai-economics-mcp.json`.

12 tools for AI budget decisions: token cost across vendors, context-window sizing, agent-hour cost, model-routing savings, LLM energy & CO₂, joules per verified task, token burn, humanoid energy budgets, Proof-Adjusted Autonomy, revocation exposure, verification bottleneck, proof debt.

- Published on npm, `runtime: node`, MIT
- **No auth and no env vars** — `env: {}` matches the docs; the underlying API is keyless and stateless
- Also in the official MCP Registry as `pl.piszczek/ai-economics` (domain-verified)
- One server per PR; no other files touched

Disclosure: PR prepared by an AI agent on behalf of the author (Michał Piszczek).