### PR TITLE
Add Talivia Agent Kit

### DIFF
--- a/packages/marketing/talivia-agent-kit.json
+++ b/packages/marketing/talivia-agent-kit.json
@@ -1,0 +1,27 @@
+{
+  "type": "mcp-server",
+  "name": "Talivia Agent Kit",
+  "packageName": "@toolsdk-remote/talivia-agent-kit",
+  "packageVersion": "0.1.0",
+  "bin": "talivia",
+  "binArgs": [
+    "mcp"
+  ],
+  "description": "Official MCP server for installing and verifying revenue-first website analytics, tracking live events, and connecting traffic to payment attribution through Talivia.",
+  "url": "https://github.com/talivia-group/agent",
+  "readme": "https://github.com/talivia-group/agent#readme",
+  "logo": "https://talivia.com/apple-touch-icon.png",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Talivia",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://talivia.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Talivia is revenue-first website analytics installed and verified by AI agents through MCP.

Official resources:
- Source: https://github.com/talivia-group/agent
- Hosted OAuth MCP: `https://talivia.com/mcp`
- npm: `@talivia/agent` version `0.1.0`
- Official MCP Registry: `io.github.talivia-group/agent`
- Integration guide: https://talivia.com/ai-agent-kit

The server helps agents install tracking, verify live events, connect payment attribution through a secure browser flow, and identify which referrers, campaigns, pages, and customer journeys become revenue.

Validation: `node scripts/validate-registry.mjs --all` passes with 0 errors and 0 warnings.