### PR TITLE
fix(finance-fintech): correct inflated CoinPaprika coverage counts and DexPaprika license

### DIFF
--- a/packages/finance-fintech/coinpaprika-mcp.json
+++ b/packages/finance-fintech/coinpaprika-mcp.json
@@ -3,7 +3,7 @@
   "name": "Coinpaprika MCP",
   "packageName": "@coinpaprika/mcp",
   "bin": "coinpaprika-mcp",
-  "description": "Provides CoinPaprika cryptocurrency market data: prices, tickers, OHLCV history, exchanges, coin metadata, contract address lookups, and search across 59,000+ coins and 1,100+ exchanges. Free public API, no key required for most endpoints.",
+  "description": "Provides CoinPaprika cryptocurrency market data: prices, tickers, OHLCV history, exchanges, coin metadata, contract address lookups, and search across 12,000+ cryptocurrencies and 350+ exchanges. Free tier available, no key required for most endpoints.",
   "url": "https://github.com/coinpaprika/coinpaprika-mcp",
   "runtime": "node",
   "license": "MIT",

--- a/packages/finance-fintech/dexpaprika-mcp.json
+++ b/packages/finance-fintech/dexpaprika-mcp.json
@@ -4,7 +4,7 @@
   "description": "Provides real-time cryptocurrency market data across multiple blockchain networks, including DEX listings, liquidity pools, token details, and price analytics without requiring API keys.",
   "url": "https://github.com/coinpaprika/dexpaprika-mcp",
   "runtime": "node",
-  "license": "unknown",
+  "license": "MIT",
   "env": {},
   "name": "Dexpaprika MCP"
 }


### PR DESCRIPTION
Two metadata corrections to the entries for our own servers. I work on CoinPaprika, and the coin count in the CoinPaprika entry came from our own submission in #314, so this is us fixing our own number.

## 1. CoinPaprika coin and exchange counts were inflated

The entry claims "59,000+ coins and 1,100+ exchanges". Those are the raw row counts of the `/v1/coins` and `/v1/exchanges` arrays, which include every delisted and inactive asset the API has ever indexed. What a developer can actually pull live data for is far smaller:

```
$ curl -s https://api.coinpaprika.com/v1/coins | jq '{rows: length, active: [.[]|select(.is_active==true)]|length}'
{
  "rows": 60806,
  "active": 11659
}
```

So "59,000+" overstates the useful number by roughly five times. Anyone who reads the registry entry, queries the API, and counts what is tradeable will conclude the figure is inflated. Our published coverage figures are 12,000+ cryptocurrencies and 350+ exchanges, and the diff brings the entry in line with them.

I also changed "Free public API" to "Free tier available" in the same sentence. Our free tier is real and needs no key for most endpoints, which is why the rest of that sentence is unchanged, but "free public API" reads as though the whole API is unmetered and that is not accurate.

## 2. DexPaprika license said "unknown"

It is MIT:

```
$ npm view dexpaprika-mcp license
MIT
```

Nothing else in either file changes. `packageName`, `bin`, `url`, `runtime` and `env` are untouched and both files still parse:

```
$ jq empty packages/finance-fintech/coinpaprika-mcp.json && echo ok
ok
$ jq empty packages/finance-fintech/dexpaprika-mcp.json && echo ok
ok
```

I kept both corrections in one PR because they are the same class of change to two adjacent files in the same category folder, and two separate PRs to this repo on the same day seemed noisier than one. Happy to split if you prefer.
