### PR TITLE
Add OptionsAhoy (remote, finance-fintech)

### DIFF
--- a/packages/finance-fintech/optionsahoy.json
+++ b/packages/finance-fintech/optionsahoy.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "OptionsAhoy",
+  "packageName": "@toolsdk-remote/optionsahoy",
+  "description": "Equity compensation planning: multi-year incentive stock option (ISO) exercise schedules with alternative minimum tax (AMT) calculations, non-qualified stock option (NSO) and restricted stock unit (RSU) calculators, RSU lot ordering, sale planning toward a cash goal, qualified small business stock (QSBS) checks, concentration analysis, and hedge pricing with federal, 50-state, and DC tax math.",
+  "url": "https://github.com/AlvisoOculus/optionsahoy-mcp",
+  "readme": "https://github.com/AlvisoOculus/optionsahoy-mcp#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://optionsahoy.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Remote entry per docs/CONTRIBUTING.md: hosted Streamable HTTP endpoint at https://optionsahoy.com/mcp (free, no auth, no env vars). 8 equity-compensation tools (ISO/AMT schedules, NSO, RSU, QSBS, concentration, hedging), tax math federal + 50 states + DC. Source: https://github.com/AlvisoOculus/optionsahoy-mcp (MIT).

`node scripts/validate-registry.mjs --base origin/main` passes locally: 1 file checked, 0 errors, 0 warnings.