### PR TITLE
Add TestMu AI MCP server (remote, streamable-http, OAuth 2.1)

### DIFF
--- a/packages/browser-automation/testmu-ai-mcp.json
+++ b/packages/browser-automation/testmu-ai-mcp.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "TestMu AI MCP Server",
+  "packageName": "@toolsdk-remote/testmu-ai-mcp",
+  "description": "Connects to the hosted TestMu AI (formerly LambdaTest) MCP endpoint for cloud testing. Orchestrates HyperExecute runs, triages automation failures from command, network, and console logs, explains SmartUI visual regressions, and runs WCAG accessibility audits.",
+  "url": "https://github.com/LambdaTest/mcp-server-guide",
+  "readme": "https://github.com/LambdaTest/mcp-server-guide#readme",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.lambdatest.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the **TestMu AI** (formerly LambdaTest) hosted MCP server as a remote entry.

`packages/browser-automation/testmu-ai-mcp.json`

### Official sources

- Setup guide / repository: https://github.com/LambdaTest/mcp-server-guide
- Documentation: https://www.testmuai.com/support/docs/testmu-mcp-server/
- Product overview: https://www.testmuai.com/mcp/
- Endpoint: `https://mcp.lambdatest.com/mcp`

### What it does

Connects MCP clients to the TestMu AI cloud testing platform so an agent can orchestrate HyperExecute runs and generate their YAML, triage automation failures from command/network/console logs, explain SmartUI visual regressions, and run WCAG accessibility audits against hosted URLs.

Placed in `browser-automation` alongside the existing `browserstack-mcp-server` entry — same problem space.

### Metadata verification

Auth metadata was checked against the live endpoint rather than taken from the docs:

- `https://mcp.lambdatest.com/.well-known/oauth-protected-resource` → `200`, authorization server `https://auth.lambdatest.com`
- `https://mcp.lambdatest.com/.well-known/oauth-authorization-server` → `200`, advertising `code` response type, PKCE `S256`, and a `registration_endpoint` (dynamic client registration)
- `https://mcp.lambdatest.com/mcp` → `401` unauthenticated, consistent with the declared OAuth requirement

Hence `remotes[0].auth.type: "oauth2"`. `auth.scopes` is omitted because the authorization server does not advertise a scope list. `env` is `{}` — authentication is interactive OAuth, so no environment variables are needed.

`license` is omitted deliberately: the source repository publishes no license file, and the contributing guide requires metadata to agree with the publisher's current documentation.

### Checklist

- [x] The PR contains only the intended package JSON file
- [x] Filename is lowercase kebab-case and the category exists
- [x] Endpoint, auth, environment variables and description checked against official sources
- [x] The effective registry identity (`@toolsdk-remote/testmu-ai-mcp`) is new — no `lambdatest`/`testmu` entry exists on `main`
- [x] Remote entry follows the `@toolsdk-remote/` and `remotes` rules; no `key` field; HTTPS, non-private endpoint
- [x] No secrets declared, so no defaults to worry about
- [x] `node scripts/validate-registry.mjs --base origin/main` passes — 1 file checked, 0 errors, 0 warnings
- [x] `biome check` passes on the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)