### PR TITLE
Add MailKite MCP server (communication)

### DIFF
--- a/packages/communication/mailkite.json
+++ b/packages/communication/mailkite.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "MailKite",
+  "packageName": "@toolsdk-remote/mailkite",
+  "description": "Give any AI agent its own real email inbox — receive inbound mail as structured tool calls and send from a verified (SPF+DKIM) domain over a hosted remote MCP server. 60+ tools covering transactional send, inbound routing, domain registration and DNS verification, templates, contact lists, broadcasts, and webhook testing.",
+  "url": "https://github.com/mailkite/mailkite-mcp",
+  "readme": "https://mailkite.dev/docs/ai-agents",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.mailkite.dev/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `packages/communication/mailkite.json` for **MailKite** — a hosted remote MCP server that gives any AI agent its own real email inbox.

- **Type:** remote (`@toolsdk-remote/mailkite`)
- **Endpoint:** `https://mcp.mailkite.dev/mcp` (Streamable HTTP)
- **Auth:** OAuth 2.1 (dynamic client registration)
- **License:** MIT
- **Repo:** https://github.com/mailkite/mailkite-mcp
- **Docs:** https://mailkite.dev/docs/ai-agents

## What it does

Receive inbound email as structured tool calls and send from a verified (SPF+DKIM) domain, no IMAP polling. 60+ tools covering transactional send + batch, attachments, inbound routes, webhooks (set/test), domain registration + DNS verification, templates, contact lists, broadcasts, and message search/get.

## Checklist

- [x] The PR contains only the intended package JSON file.
- [x] Filename is lowercase kebab-case (`mailkite.json`) in an existing category (`communication`).
- [x] Endpoint, auth, and license checked against our own current docs/config (verified live: `GET /mcp` → 405, `POST initialize` → JSON-RPC, `/.well-known/oauth-protected-resource` → valid RFC 9728 metadata).
- [x] Effective registry identity (`@toolsdk-remote/mailkite`) is new — confirmed no existing entry.
- [x] Remote entry follows the `@toolsdk-remote/` + `remotes` rules, `auth.type: oauth2`.
- [x] No secrets/env vars needed for the documented capability (headless clients may alternatively use a bearer API key, but that's not modeled here per the OAuth2-only `auth.type` rule).
- [x] `node scripts/validate-registry.mjs --base origin/main` passes (0 errors, 0 warnings).

## Disclosure

Submitted by a MailKite team member (`bucabay`), with AI (Claude Code) assistance drafting the entry and PR description. All facts (endpoint, auth, license, tool count) were independently verified against the live server and published package metadata before submission.