### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/packages/marketing/autoposting.json
+++ b/packages/marketing/autoposting.json
@@ -1,0 +1,22 @@
+{
+  "type": "mcp-server",
+  "name": "Autoposting",
+  "packageName": "@toolsdk-remote/autoposting",
+  "description": "Remote MCP server for Autoposting: draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube.",
+  "url": "https://github.com/Autoposting-ai/autoposting-mcp",
+  "readme": "https://docs.autoposting.ai/mcp/overview",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Autoposting",
+  "logo": "https://autoposting.ai/autoposting-logo.svg",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.autoposting.ai/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds one remote entry: `packages/marketing/autoposting.json`.

Autoposting is a hosted MCP server for a full social workflow — draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube (69 tools).

- Endpoint: `https://app.autoposting.ai/mcp` (Streamable HTTP, OAuth 2.1 with Dynamic Client Registration — no client id/secret, nothing to install)
- Repository: https://github.com/Autoposting-ai/autoposting-mcp · Docs: https://docs.autoposting.ai/mcp/overview
- Server card: https://app.autoposting.ai/.well-known/mcp/server-card.json
- Published in the official MCP registry as `ai.autoposting/autoposting`.

`node scripts/validate-registry.mjs --base origin/main` passes (1 file, 0 errors, 0 warnings).
