### PR TITLE
Add SV Number MCP server (SMS verification numbers for AI agents)

### DIFF
--- a/packages/communication/sv-number-mcp.json
+++ b/packages/communication/sv-number-mcp.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "SV Number",
+  "packageName": "sv-number-mcp",
+  "description": "Phone numbers for AI agents: order a private number for one service in one country, wait for the SMS verification code (returned already parsed), request another code on the same number, cancel for a refund, and compute TOTP codes locally (RFC 6238).",
+  "url": "https://github.com/sv-number/mcp-server",
+  "readme": "https://github.com/sv-number/mcp-server#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {
+    "SVN_API_KEY": {
+      "description": "API key from the sms-verification-number.com profile page.",
+      "required": true,
+      "secret": true
+    }
+  }
+}


### PR DESCRIPTION
Adds **SV Number** to `packages/communication/`.

Local Node entry: published npm package [`sv-number-mcp`](https://www.npmjs.com/package/sv-number-mcp) (MIT, stdio, official `@modelcontextprotocol/sdk`, nine tools). Source and docs: https://github.com/sv-number/mcp-server. Also listed on the official MCP Registry as `io.github.sv-number/mcp-server`. One required secret env `SVN_API_KEY`, documented in the README.