### PR TITLE
Add: Data Studio Agent MCP server

### DIFF
--- a/packages/databases/data-studio-agent.json
+++ b/packages/databases/data-studio-agent.json
@@ -1,0 +1,10 @@
+{
+  "type": "mcp-server",
+  "packageName": "@geek-fun/data-studio-mcp",
+  "description": "Unified MCP server giving AI coding agents direct access to SQL (70+ databases via SqlKit: PostgreSQL, MySQL, SQL Server, SQLite, ClickHouse, Snowflake, BigQuery) and NoSQL (Elasticsearch, MongoDB, DynamoDB via DocKit) — local-first, credentials never leave the machine.",
+  "url": "https://github.com/geek-fun/data-studio-agent",
+  "runtime": "node",
+  "license": "apache-2.0",
+  "env": {},
+  "name": "Data Studio Agent"
+}


### PR DESCRIPTION
## What

Adds [Data Studio Agent](https://github.com/geek-fun/data-studio-agent) to the `databases` category.

- **packageName:** `@geek-fun/data-studio-mcp` (npm)
- **runtime:** node
- **license:** Apache-2.0
- **Description:** Unified MCP server giving AI coding agents direct access to SQL (70+ databases via SqlKit) and NoSQL (Elasticsearch, MongoDB, DynamoDB via DocKit) — local-first, credentials never leave the machine.

## Validation

```bash
make validate packages/databases/data-studio-agent.json
```
