### PR TITLE
Add Skillselion MCP server to developer-tools

### DIFF
--- a/packages/developer-tools/skillselion-mcp.json
+++ b/packages/developer-tools/skillselion-mcp.json
@@ -1,0 +1,11 @@
+{
+  "type": "mcp-server",
+  "packageName": "skillselion-mcp",
+  "description": "Searches a catalog of community agent skills, MCP servers, plugins and marketplaces ranked by install count, then materializes a matching SKILL.md and its bundled scripts into the session so the agent follows it mid-task.",
+  "url": "https://github.com/skillselion/skillselion-mcp",
+  "readme": "https://github.com/skillselion/skillselion-mcp#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "name": "Skillselion"
+}


### PR DESCRIPTION
Adds one entry: `packages/developer-tools/skillselion-mcp.json`.

**What it is:** an MCP server that searches a catalog of community agent skills, MCP servers, plugins and marketplaces (ranked by install count) and materializes the matching `SKILL.md` plus its bundled scripts and references into the running session, so a coding agent follows a proven recipe instead of improvising.

**Source verification**
- npm: [`skillselion-mcp`](https://www.npmjs.com/package/skillselion-mcp) v0.9.6, public, runs via `npx -y skillselion-mcp`
- Repo: https://github.com/skillselion/skillselion-mcp — MIT, public
- Runtime: node · stdio · no environment variables, no auth, no API key (`env: {}`)
- Also published in the official MCP Registry as `io.github.skillselion/skillselion-mcp` (status ACTIVE)

**Checklist**
- [x] One MCP server, one JSON file, no generated-index or README edits
- [x] Metadata matches the publisher's current documentation
- [x] `node scripts/validate-registry.mjs --base origin/main` passes — "checked 1 file(s): 0 error(s), 0 warning(s)"