### PR TITLE
Add LWC memory MCP server

### DIFF
--- a/packages/knowledge-memory/lwc.json
+++ b/packages/knowledge-memory/lwc.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "name": "LWC",
+  "packageName": "@i-xor/lwc",
+  "description": "Read-only MCP server for bounded exploration of source-grounded project memory with citations, provenance, SQLite/FTS5 retrieval, and optional document and code graphs.",
+  "url": "https://github.com/JanYork/llm-wiki-cli",
+  "readme": "https://github.com/JanYork/llm-wiki-cli#native-agent-setup",
+  "runtime": "node",
+  "binArgs": ["serve", "--mcp"],
+  "license": "Apache-2.0",
+  "env": {}
+}


### PR DESCRIPTION
## Summary

Add LWC to the Knowledge & Memory registry category. LWC exposes bounded, read-only exploration of source-grounded project memory through one MCP tool.

## Source verification

- npm package: `@i-xor/lwc@0.14.7`
- executable: `lwc`
- MCP command: `lwc serve --mcp`
- runtime: Node.js 22+
- license: Apache-2.0
- authentication/environment variables: none

Official source: https://github.com/JanYork/llm-wiki-cli#native-agent-setup

## Validation

```text
Registry validation checked 1 file(s): 0 error(s), 0 warning(s).
```

The PR changes only `packages/knowledge-memory/lwc.json`.