### PR TITLE
Add AI Tool Directory remote MCP server

### DIFF
--- a/packages/search-data-extraction/tool-directory.json
+++ b/packages/search-data-extraction/tool-directory.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "AI Tool Directory",
+  "packageName": "@toolsdk-remote/ai-tooldirectory-catalog",
+  "description": "Search a curated catalog of 2,000+ AI tools — pricing, features, ratings, categories, and editorially curated alternatives — plus checks for whether a tool is still active, defunct, or acquired. Tools: search_tools, get_tool, check_tool_status, find_alternatives, compare_tools, list_tools.",
+  "url": "https://github.com/AI-Directory-Partners/tooldirectory-mcp",
+  "readme": "https://github.com/AI-Directory-Partners/tooldirectory-mcp#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://tooldirectory.ai/api/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds one remote MCP server entry: `packages/search-data-extraction/tool-directory.json`.

- **Repo:** https://github.com/AI-Directory-Partners/tooldirectory-mcp (MIT)
- **Endpoint:** `https://tooldirectory.ai/api/mcp` — streamable HTTP, read-only, no auth
- **Official MCP registry:** `ai.tooldirectory/catalog`
- **npm (stdio front-end):** https://www.npmjs.com/package/tooldirectory-mcp
- **Tools (6):** `search_tools`, `get_tool`, `check_tool_status`, `find_alternatives`, `compare_tools`, `list_tools`

It indexes 2,000+ AI tools with pricing, features, ratings, categories and editorially curated alternatives. `check_tool_status` reports whether a tool is still active, defunct, or acquired, backed by a maintained graveyard of shut-down and acquired AI tools — useful for agents that would otherwise recommend products that no longer exist.

Listed without `auth` because the endpoint is fully unauthenticated and read-only.

`node scripts/validate-registry.mjs --all` passes: 4909 files, 0 errors, 0 warnings. One file added, nothing else touched.