### PR TITLE
Add agent-qa MCP server

### DIFF
--- a/packages/browser-automation/agent-qa.json
+++ b/packages/browser-automation/agent-qa.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "packageName": "agent-qa",
+  "description": "Runs natural-language web and mobile tests, retains execution memory, and exposes authoring, execution, artifact, and triage tools to MCP clients.",
+  "url": "https://github.com/vostride/agent-qa",
+  "readme": "https://vostride.com/docs/agent-qa",
+  "runtime": "node",
+  "license": "FSL-1.1-ALv2",
+  "binArgs": ["mcp"],
+  "env": {},
+  "name": "agent-qa"
+}


### PR DESCRIPTION
## Summary

Adds the published `agent-qa` npm package to the Browser Automation registry. Its `agent-qa mcp` command exposes natural-language web/mobile test authoring, execution, artifact, and triage tools over stdio while retaining execution memory across runs.

## Package details

- npm package: `agent-qa` (verified at version 0.1.21)
- runtime: Node.js 24+
- command: `agent-qa mcp`
- current license: FSL-1.1-ALv2, converting to Apache-2.0 after two years

## Validation

- `node --test scripts/lib/registry-validator.node-test.mjs` — 10/10 tests passed
- `node scripts/validate-registry.mjs --all` — 4,909 files checked, 0 errors and 0 warnings
- `node scripts/validate-registry.mjs --base origin/main` — changed entry checked, 0 errors and 0 warnings
- `git diff --check` passes

Per the contributor instructions, the submitted package was not executed locally.

Project disclosure: this submission is for agent-qa itself.
