### PR TITLE
Add Proofite MCP server

### DIFF
--- a/packages/search-data-extraction/proofite.json
+++ b/packages/search-data-extraction/proofite.json
@@ -1,0 +1,22 @@
+{
+  "type": "mcp-server",
+  "name": "Proofite",
+  "packageName": "proofite-mcp",
+  "description": "Read your AI-written daily news briefing and retune the filter behind it: RSS feeds, newsletters, monitored web searches, topic preferences, read-later queue and podcast. 27 tools plus resources and prompts. Hosted remote at https://proofite.com/mcp, or run the stdio bridge via npx proofite-mcp. Published in the official MCP Registry as com.proofite/proofite.",
+  "url": "https://github.com/hanicker/proofite-mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "hanicker",
+  "env": {
+    "PROOFITE_API_KEY": {
+      "description": "Proofite API key, created at https://proofite.com/app/settings under Connections. Keys can be created read-only.",
+      "required": true
+    }
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://proofite.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds one JSON file: `packages/search-data-extraction/proofite.json`. No other files touched (no README, no indexes).

**Proofite** turns the sources a person chooses — newsletters, RSS feeds, monitored web searches, saved links — into one AI-written daily briefing, also available as a podcast. The MCP server lets an agent read that briefing and retune the filter behind it: topics, depth, technicality, schedule, sources.

Sources for the metadata:
- npm package: https://www.npmjs.com/package/proofite-mcp (published, v1.0.0, `bin: proofite-mcp`)
- Remote endpoint: https://proofite.com/mcp — Streamable HTTP, public, documented at the same URL
- Auth: `PROOFITE_API_KEY` as a Bearer header; keys are created at https://proofite.com/app/settings and can be made read-only
- Official MCP Registry: `com.proofite/proofite`
- Repository and license: https://github.com/hanicker/proofite-mcp (MIT)