### PR TITLE
fix: point UIZZE registry entry at canonical source

### DIFF
--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -2,8 +2,9 @@
   "type": "mcp-server",
   "name": "UIZZE",
   "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
-  "description": "Real UI references, design contracts, validation, audits, and critiques for coding agents. The public catalog is free to browse; hosted MCP workflows require full access.",
-  "url": "https://github.com/uizze/uizze-mcp",
+  "description": "Hosted UIZZE MCP for live UI references, design contracts, validation, audits, and screenshot critique across 800,000+ real web and iOS screens. The free anti-ui-slop Skill and no-account check_ui_slop preview are available separately.",
+  "url": "https://github.com/uizze/uizze",
+  "readme": "https://github.com/uizze/uizze/tree/main/integrations/mcp/README.md",
   "runtime": "node",
   "env": {
     "UIZZE_AGENT_TOKEN": {

--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -2,9 +2,9 @@
   "type": "mcp-server",
   "name": "UIZZE",
   "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
-  "description": "Hosted UIZZE MCP for live UI references, design contracts, validation, audits, and screenshot critique across 800,000+ real web and iOS screens. The free anti-ui-slop Skill and no-account check_ui_slop preview are available separately.",
+  "description": "Authenticated UIZZE MCP for coding agents: find_ui_references and find_ui_materials provide focused UI references and hosted design materials grounded in 800,000+ real web and iOS screens. The free anti-ui-slop Skill and conservative GitHub Action are available separately.",
   "url": "https://github.com/uizze/uizze",
-  "readme": "https://github.com/uizze/uizze/tree/main/integrations/mcp/README.md",
+  "readme": "https://uizze.com/docs",
   "runtime": "node",
   "env": {
     "UIZZE_AGENT_TOKEN": {


### PR DESCRIPTION
## Summary

- update the existing UIZZE registry record to the canonical `uizze/uizze` repository
- add the official integration README link
- align the description with the free anti-ui-slop Skill, no-account preview, and full hosted MCP scope

The current record still points at the retired `uizze/uizze-mcp` repository even though the source project moved to `uizze/uizze`.

## Validation

- `node scripts/validate-registry.mjs --all`
- `git diff --check`
