### PR TITLE
fix: point UIZZE registry entry to canonical preview

### DIFF
--- a/packages/coding-agents/uizze.json
+++ b/packages/coding-agents/uizze.json
@@ -2,19 +2,14 @@
   "type": "mcp-server",
   "name": "UIZZE",
   "packageName": "@toolsdk-remote/io-github-samuelbushi-uizze",
-  "description": "Real UI references, design contracts, validation, audits, and critiques for coding agents. The public catalog is free to browse; hosted MCP workflows require full access.",
-  "url": "https://github.com/uizze/uizze-mcp",
+  "description": "Free anti-UI-slop Skill and deterministic no-account preview MCP for coding agents. Full UIZZE adds live research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.",
+  "url": "https://github.com/uizze/uizze",
   "runtime": "node",
-  "env": {
-    "UIZZE_AGENT_TOKEN": {
-      "description": "UIZZE agent token for the full-access hosted MCP workflow.",
-      "required": true
-    }
-  },
+  "env": {},
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://uizze.com/mcp"
+      "url": "https://uizze.com/mcp/preview"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the retired uizze/uizze-mcp source with the canonical uizze/uizze repository
- point the remote entry at the free no-account preview endpoint
- remove the obsolete token requirement from the preview listing
- keep the public 800,000+ real web and iOS screen scope separate from the free preview

## Verification
- node scripts/validate-registry.mjs --all (4908 files, 0 errors, 0 warnings)
- git diff --check

Source: https://github.com/uizze/uizze/blob/main/integrations/mcp/server.json
Preview: https://uizze.com/mcp/preview