### PR TITLE
Add SandBase Harness MCP server

### DIFF
--- a/packages/code-execution/sandbase-harness.json
+++ b/packages/code-execution/sandbase-harness.json
@@ -1,0 +1,31 @@
+{
+  "type": "mcp-server",
+  "name": "SandBase Harness MCP",
+  "packageName": "ghcr.io/sandbaseai/sandbase-harness-mcp",
+  "description": "Connects MCP clients to a self-hosted SandBase Harness runtime for agent, session, streamed turn, artifact, and cancellation operations.",
+  "url": "https://github.com/sandbaseai/sandbase-harness",
+  "readme": "https://github.com/sandbaseai/sandbase-harness#readme",
+  "runtime": "docker",
+  "license": "Apache-2.0",
+  "binArgs": [
+    "run",
+    "--rm",
+    "-i",
+    "-e",
+    "MANAGED_AGENTS_URL",
+    "-e",
+    "MANAGED_AGENTS_API_KEY",
+    "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4"
+  ],
+  "env": {
+    "MANAGED_AGENTS_URL": {
+      "description": "Base URL of the SandBase Harness runtime API.",
+      "required": true
+    },
+    "MANAGED_AGENTS_API_KEY": {
+      "description": "API key for an authenticated SandBase Harness runtime.",
+      "required": false,
+      "secret": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the public SandBase Harness MCP bridge as a Docker runtime entry under `code-execution`. The bridge connects MCP clients to a self-hosted Harness runtime for agent, session, streamed turn, artifact, and cancellation operations.

Official sources:

- Repository and Docker usage: https://github.com/sandbaseai/sandbase-harness#readme
- Image: `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.4`
- License: Apache-2.0

Disclosure: I help maintain the SandBase project.

## Validation

- [x] Contains only `packages/code-execution/sandbase-harness.json`
- [x] Filename is lowercase kebab-case and the category exists
- [x] Verified the public OCI tag with `docker manifest inspect` (linux/amd64 and linux/arm64)
- [x] Checked package identity, Docker arguments, environment variables, and license against the official README
- [x] Confirmed no existing SandBase entry or open submission
- [x] `node scripts/validate-registry.mjs --base origin/main`: 1 file checked, 0 errors, 0 warnings
- [x] `git diff --check` passes