### PR TITLE
Add AdMapix MCP server to marketing registry

### DIFF
--- a/packages/marketing/admapix-mcp.json
+++ b/packages/marketing/admapix-mcp.json
@@ -3,7 +3,7 @@
   "name": "AdMapix MCP",
   "packageName": "admapix-mcp",
   "packageVersion": "1.0.0",
-  "description": "Searches competitor ad creatives and mobile app market data, including rankings, downloads, and revenue.",
+  "description": "Searches competitor ad creatives with keyword, country, date, creative type, and industry filters.",
   "url": "https://github.com/fly0pants/admapix",
   "readme": "https://github.com/fly0pants/admapix#readme",
   "runtime": "python",

--- a/packages/marketing/admapix-mcp.json
+++ b/packages/marketing/admapix-mcp.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "AdMapix MCP",
+  "packageName": "admapix-mcp",
+  "packageVersion": "1.0.0",
+  "description": "Searches competitor ad creatives and mobile app market data, including rankings, downloads, and revenue.",
+  "url": "https://github.com/fly0pants/admapix",
+  "readme": "https://github.com/fly0pants/admapix#readme",
+  "runtime": "python",
+  "env": {
+    "ADMAPIX_API_KEY": {
+      "description": "API key for AdMapix data access.",
+      "required": true,
+      "secret": true
+    }
+  }
+}


### PR DESCRIPTION
Adds the published `admapix-mcp` Python MCP server to the Marketing category.

- Package: https://pypi.org/project/admapix-mcp/
- Source and README: https://github.com/fly0pants/admapix
- Official website: https://www.admapix.com/
- The entry contains only verified package metadata, the Python runtime, and the documented `ADMAPIX_API_KEY` secret.