### PR TITLE
Add Wondel.ai Skills MCP (knowledge-memory) and AI Developer Toolkit MCP (developer-tools)

### DIFF
--- a/packages/developer-tools/mjaskolski-developer-toolkit-mcp.json
+++ b/packages/developer-tools/mjaskolski-developer-toolkit-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "AI Developer Toolkit MCP",
+  "packageName": "developer-toolkit-mcp",
+  "description": "Read-only remote MCP endpoint over 950+ AI-development guides (Cursor, Claude Code, Codex) in EN+PL: search (query to ranked results) and fetch (id to full article markdown). No account, no API key.",
+  "url": "https://github.com/mjaskolski/developer-toolkit-mcp",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://developertoolkit.ai/mcp"
+    }
+  ]
+}

--- a/packages/knowledge-memory/mjaskolski-wondel-skills-mcp.json
+++ b/packages/knowledge-memory/mjaskolski-wondel-skills-mcp.json
@@ -1,0 +1,15 @@
+{
+  "type": "mcp-server",
+  "name": "Wondel.ai Skills MCP",
+  "packageName": "wondel-skills-mcp",
+  "description": "Read-only remote MCP server over 50 book-based agent skills and 12 guided journeys: routes a task to the right framework (recommend_skills) and serves the real SKILL.md in-session (load_skill). No install, no account, no auth.",
+  "url": "https://github.com/mjaskolski/wondel-skills-mcp",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://skills.wondel.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Two related remote MCP servers from the same publisher (Wondel.ai), both public Streamable HTTP endpoints, no auth:

1. **Wondel.ai Skills MCP** — `packages/knowledge-memory/mjaskolski-wondel-skills-mcp.json` — 50 book-based agent skills + 12 guided journeys; recommend_skills routes a task to the right framework, load_skill serves the real SKILL.md. Endpoint: https://skills.wondel.ai/mcp — docs: https://skills.wondel.ai/mcp — official MCP registry: `io.github.mjaskolski/wondel-skills-mcp`
2. **AI Developer Toolkit MCP** — `packages/developer-tools/mjaskolski-developer-toolkit-mcp.json` — 950+ AI-development guides (Cursor, Claude Code, Codex), EN+PL; search + fetch. Endpoint: https://developertoolkit.ai/mcp — docs: https://developertoolkit.ai/en/mcp/ — official MCP registry: `io.github.mjaskolski/developer-toolkit-mcp`