### PR TITLE
Add APITube News remote MCP server

### DIFF
--- a/packages/search-data-extraction/apitube-news.json
+++ b/packages/search-data-extraction/apitube-news.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "APITube News",
+  "packageName": "@toolsdk-remote/apitube-news",
+  "description": "Hosted news search over the APITube News API: 500,000+ sources, 177 countries, 59 languages, with sentiment scores and named entities on every article. Two read-only tools: search_news, covering most of the News API filter set, and suggest, which resolves a name into entity, category, topic and industry IDs. Tool calls need an APITube API key in an Authorization: Bearer header and a paid plan; unauthenticated clients still get initialize and tools/list.",
+  "url": "https://github.com/apitube/news-api-mcp",
+  "readme": "https://github.com/apitube/news-api-mcp#readme",
+  "logo": "https://apitube.io/favicons/android-icon-192x192.png",
+  "author": "APITube",
+  "license": "MIT",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.apitube.io/"
+    }
+  ]
+}


### PR DESCRIPTION
Adds **APITube News**, a hosted (Streamable HTTP) MCP server for the APITube News API, as a remote entry in `packages/search-data-extraction/apitube-news.json`.

## Entry

| Field | Value |
|---|---|
| `packageName` | `@toolsdk-remote/apitube-news` |
| Endpoint | `https://mcp.apitube.io/` (Streamable HTTP, JSON-RPC 2.0) |
| Repository | https://github.com/apitube/news-api-mcp |
| License | MIT ([LICENSE](https://github.com/apitube/news-api-mcp/blob/main/LICENSE)) |
| Tools | `search_news`, `suggest` — both read-only |
| Prompts | `monitor_company`, `topic_sentiment`, `breaking_news`, `compare_coverage` |
| Official MCP Registry | `io.apitube/news` ([server.json](https://github.com/apitube/news-api-mcp/blob/main/server.json)) |

`search_news` exposes most of the News API filter set — keywords, language, country, source domain and quality rank, sentiment range, named entities, media, date ranges, sorting, faceting, highlighting. `suggest` resolves a name such as "Tesla" into the entity, category, topic and industry IDs the precise filters take.

## Auth: listed without `auth`, per the contributing guide

The server authenticates with `Authorization: Bearer <API_KEY>` (or `X-API-Key`), which the registry schema does not model, and `CONTRIBUTING.md` says not to express Bearer auth as OAuth2 or as an env var. So the entry carries `env: {}`, no `auth` block, and the description states the limitation: tool calls need an API key and a paid plan (Starter, $29/mo, and up — the free tier is REST-only), while an unauthenticated client still gets `initialize`, `tools/list` and `prompts/list`.

Verified against the live endpoint just now, no key sent:

```bash
curl -s -X POST https://mcp.apitube.io/ -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"curl","version":"1.0.0"}},"id":1}'
# → serverInfo {"name":"APITube News MCP-Server","version":"1.0.0"}, capabilities: tools, prompts

curl -s -X POST https://mcp.apitube.io/ -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'
# → search_news, suggest
```

One more limitation worth knowing before you try it: through MCP a single response returns at most 25 articles (`per_page` defaults to 10 and is clamped to 25), and a title search covers at most 31 days unless an explicit `published_at` range is given.

## Checks

- `node scripts/validate-registry.mjs --base origin/main` → `1 file(s): 0 error(s), 0 warning(s)`
- `biome check` on the new file → clean
- New identity: no `apitube` entry and no `mcp.apitube.io` endpoint exists on `main`
- One file, one server, nothing generated touched

## Docs

- Server reference: https://docs.apitube.io/platform/news-api/ai/mcp-server
- Parameters: https://docs.apitube.io/platform/news-api/everything
- Pricing: https://apitube.io/pricing
- Server card: https://docs.apitube.io/.well-known/mcp/server-card.json
