### PR TITLE
Add 404.directory remote MCP server

### DIFF
--- a/packages/aggregators/404-directory.json
+++ b/packages/aggregators/404-directory.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "404.directory",
+  "packageName": "@toolsdk-remote/404-directory",
+  "description": "Hosted read-only MCP gateway for one-call official documentation search across OpenAI, Microsoft Learn, AWS, and Cloudflare, plus capability-based tool discovery, trust comparison, live schema inspection, and approved remote execution.",
+  "readme": "https://github.com/MM-sheng/404-directory#readme",
+  "url": "https://github.com/MM-sheng/404-directory",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "MM-sheng",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://404.directory/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds one remote-only MCP registry entry for 404.directory under Aggregators.

- Public Streamable HTTP endpoint: `https://404.directory/mcp`
- No authentication or environment variables required
- One-call official documentation search across OpenAI, Microsoft Learn, AWS, and Cloudflare
- Additional read-only discovery, trust comparison, schema inspection, and allowlisted execution tools
- Official MCP Registry v0.7.1: https://registry.modelcontextprotocol.io/v0.1/servers/io.github.MM-sheng%2F404-directory/versions/latest
- Source and documentation: https://github.com/MM-sheng/404-directory

## Validation

`node scripts/validate-registry.mjs --base upstream/main`

Result: 1 file checked, 0 errors, 0 warnings.