### PR TITLE
Add Pocket Drives remote MCP (travel-transportation)

### DIFF
--- a/packages/travel-transportation/pocket-drives.json
+++ b/packages/travel-transportation/pocket-drives.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "name": "Pocket Drives",
+  "packageName": "@toolsdk-remote/pocket-drives",
+  "description": "Search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Remote Streamable HTTP, no auth.",
+  "url": "https://github.com/RevList/pocket-drives-mcp",
+  "readme": "https://github.com/RevList/pocket-drives-mcp#readme",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://pocketdrives.ai/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Pocket Drives, a public remote Streamable HTTP MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts.

- Endpoint: `https://pocketdrives.ai/mcp` (no auth)
- Tools: `https://pocketdrives.ai/mcp/tools`
- Source: https://github.com/RevList/pocket-drives-mcp
- Transport: Streamable HTTP (`@toolsdk-remote/pocket-drives`)
- Category: travel-transportation

License omitted because the source repo has no LICENSE file.