### PR TITLE
Add Famulor remote MCP server

### DIFF
--- a/packages/communication/famulor-mcp.json
+++ b/packages/communication/famulor-mcp.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "Famulor MCP",
+  "packageName": "@toolsdk-remote/io-famulor-mcp",
+  "description": "Connects AI clients to Famulor voice assistants, communication history, calls, messaging, campaigns, knowledge, automations, tasks, settings, and related workspace tools.",
+  "url": "https://www.famulor.io",
+  "readme": "https://docs.famulor.io/en/api-reference/introduction",
+  "logo": "https://app.famulor.io/famulor-mcp-logo.svg",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://app.famulor.io/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Famulor as an official OAuth-protected remote Streamable HTTP MCP server.

## Submission checklist

- [x] Only one new package JSON file
- [x] File is in the existing `communication` category
- [x] Registry identity `@toolsdk-remote/io-famulor-mcp` is new
- [x] Production HTTPS endpoint: `https://app.famulor.io/mcp`
- [x] OAuth 2.1 protected-resource metadata is live
- [x] Official documentation: https://docs.famulor.io/en/api-reference/introduction
- [x] `node scripts/validate-registry.mjs --base origin/main` passes with 0 errors and 0 warnings
- [x] No credentials, secrets, generated indexes, or unrelated files are included

The endpoint is maintained by Famulor and exposes tenant-scoped assistant, communication history, calls, messaging, campaigns, knowledge, automations, tasks, settings, and related workspace tools after authenticated user consent.