### PR TITLE
Add Cohesivity remote MCP server

### DIFF
--- a/packages/cloud-platforms/cohesivity.json
+++ b/packages/cloud-platforms/cohesivity.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "Cohesivity",
+  "packageName": "@toolsdk-remote/cohesivity",
+  "description": "cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.",
+  "url": "https://github.com/cohesivity-org/cohesivity-plugin",
+  "readme": "https://github.com/cohesivity-org/cohesivity-plugin#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Cohesivity",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://cohesivity.ai/mcp/manage",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the official Cohesivity hosted MCP server to `packages/cloud-platforms/cohesivity.json`.

cohesivity.ai offers free agent native backend services. Anonymous account (no-signup) to get started through MCP or API. Hosting, postgres, email, storage, containers, LLMs, voice and third-party APIs. Includes free tiers and 5 USD/mo in AI and Search credits. Top-ups through x402.

## Official sources

- Repository and bundled skill/plugin: https://github.com/cohesivity-org/cohesivity-plugin
- Endpoint: https://cohesivity.ai/mcp/manage
- Authentication docs: https://cohesivity.ai/auth.md
- OAuth protected-resource metadata: https://cohesivity.ai/.well-known/oauth-protected-resource/mcp/manage
- OAuth authorization-server metadata: https://cohesivity.ai/.well-known/oauth-authorization-server
- MCP server card: https://cohesivity.ai/.well-known/mcp/manage/server-card.json

## Metadata verification

- The live endpoint returns `401` without a bearer token and advertises the protected-resource metadata URL.
- Authorization metadata advertises authorization code, PKCE S256, and dynamic client registration.
- The server card identifies the endpoint as Streamable HTTP.
- The official repository is MIT licensed.
- The linked repository also bundles the Cohesivity skill, plugin, and no-signup local bootstrap MCP. ToolSDK's registry schema indexes the hosted MCP server only.

## Validation

- `node scripts/validate-registry.mjs --base upstream/main`
- `node --test scripts/lib/registry-validator.node-test.mjs scripts/validate-registry.node-test.mjs`
- `git diff --check upstream/main...HEAD`

Disclosure: This is an official Cohesivity submission.
