### PR TITLE
Add FluentEDI remote MCP server

### DIFF
--- a/packages/developer-tools/fluentedi-tools.json
+++ b/packages/developer-tools/fluentedi-tools.json
@@ -1,0 +1,16 @@
+{
+  "type": "mcp-server",
+  "packageName": "@toolsdk-remote/fluentedi-tools",
+  "name": "FluentEDI",
+  "description": "45 deterministic tools for work a language model cannot do reliably by reasoning, free and with no API key. Retail EDI is the deepest coverage: parse X12 850 purchase orders, 856 ASNs, 810 invoices, 855 and 997; generate an 856 with correct HL parent pointers and a fixed-width 106-character ISA; validate envelopes and hierarchy; decode a 997 acknowledgment into plain language; compute GS1 mod-10 check digits. Alongside that: current time and timezone arithmetic, delivery-window containment, cron schedules, exact maths, JSON repair with line and column error localisation, JSONPath, RFC 8785 canonical JSON with a CIDv1, Ed25519/ECDSA/RSA signature verification, secret and PII scanning, link-liveness checking, endpoint assertion, and text position conversion across byte, UTF-16, code point and grapheme indexes. Every tool is read-only and idempotent, so it is safe to auto-run.",
+  "url": "https://fluentedi.com",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://fluentedi.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds FluentEDI as a remote MCP server under `developer-tools`.

- `remotes[0]`: `streamable-http` at `https://fluentedi.com/mcp` — public HTTPS, not localhost or a private network
- **No authentication.** No key, no signup, no rate limit, so there are no credentials to supply for review
- Every tool is read-only and idempotent
- Already published to the official MCP registry as `com.fluentedi/tools`

45 deterministic tools. The deepest coverage is retail X12 EDI, which is close to unserved for agents: parsing 850/856/810/855/997, generating an 856 with correct HL parent pointers and a fixed-width 106-character ISA, envelope and hierarchy validation, decoding a 997 into plain language, and GS1 check digits. Alongside that, timezone and delivery-window arithmetic, cron, exact maths, JSON repair with line/column error localisation, canonical JSON with a CIDv1, signature verification, secret scanning, link checking and endpoint assertion.

One thing worth flagging for reviewers: `tools/list` returns 17 by default rather than all 45, because clients cap how many tools they hold across all servers at once and Cursor silently drops the overflow past roughly forty. The rest are reachable through `tool_search`, `tool_describe` and `tool_call`, or by appending `?tools=all` to the endpoint.

Verifiable without installing anything:

```
curl -s https://fluentedi.com/openapi.json | head
curl -sX POST https://fluentedi.com/mcp -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```