### PR TITLE
Add Worklittle Jobs remote MCP

### DIFF
--- a/packages/search-data-extraction/worklittle-jobs.json
+++ b/packages/search-data-extraction/worklittle-jobs.json
@@ -1,0 +1,23 @@
+{
+  "type": "mcp-server",
+  "name": "Worklittle Jobs",
+  "packageName": "@toolsdk-remote/worklittle-jobs",
+  "description": "Search jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.",
+  "url": "https://github.com/worklittle/jobs-mcp",
+  "readme": "https://docs.worklittle.com/mcp",
+  "runtime": "node",
+  "license": "MIT",
+  "logo": "https://raw.githubusercontent.com/worklittle/jobs-mcp/main/logo.png",
+  "author": "Worklittle",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.worklittle.com/",
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["jobs:read", "jobs:apply", "jobs:apply_with_ai"]
+      }
+    }
+  ]
+}

--- a/packages/search-data-extraction/worklittle-jobs.json
+++ b/packages/search-data-extraction/worklittle-jobs.json
@@ -2,7 +2,7 @@
   "type": "mcp-server",
   "name": "Worklittle Jobs",
   "packageName": "@toolsdk-remote/worklittle-jobs",
-  "description": "Search jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.",
+  "description": "Search over 4 million jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.",
   "url": "https://github.com/worklittle/jobs-mcp",
   "readme": "https://docs.worklittle.com/mcp",
   "runtime": "node",

--- a/packages/search-data-extraction/worklittle-jobs.json
+++ b/packages/search-data-extraction/worklittle-jobs.json
@@ -2,7 +2,7 @@
   "type": "mcp-server",
   "name": "Worklittle Jobs",
   "packageName": "@toolsdk-remote/worklittle-jobs",
-  "description": "Search over 4 million jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.",
+  "description": "Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love.",
   "url": "https://github.com/worklittle/jobs-mcp",
   "readme": "https://docs.worklittle.com/mcp",
   "runtime": "node",


### PR DESCRIPTION
Adds Worklittle Jobs remote MCP.

- Repo: https://github.com/worklittle/jobs-mcp
- Endpoint: https://mcp.worklittle.com/
- Docs: https://docs.worklittle.com/mcp
- Support: support@worklittle.com