### PR TITLE
Add Lumi App Finder

### DIFF
--- a/packages/search-data-extraction/lumi-app-finder.json
+++ b/packages/search-data-extraction/lumi-app-finder.json
@@ -1,0 +1,12 @@
+{
+  "type": "mcp-server",
+  "name": "Lumi App Finder",
+  "packageName": "ghcr.io/alice51849/lumi-app-finder",
+  "description": "Matches a task, app name, or buyer need to Lumi Studio's live iOS apps and returns publisher-authored, editorially localized context, the purchase model, a guide link, and a direct App Store link for the matching storefront. First-party publisher catalog: results are text relevance matches, not an independent ranking, review, or measured search volume. The runtime is offline, needs no account or API key, and makes no network request.",
+  "url": "https://github.com/alice51849/lumi-mcp",
+  "readme": "https://github.com/alice51849/lumi-mcp#readme",
+  "runtime": "docker",
+  "license": "MIT",
+  "binArgs": ["run", "--rm", "-i", "ghcr.io/alice51849/lumi-app-finder:1.2.0"],
+  "env": {}
+}


### PR DESCRIPTION
Adds one entry: `packages/search-data-extraction/lumi-app-finder.json`.

**Lumi App Finder** exposes a single read-only tool, `find_ios_apps`, which matches a task, app name, or buyer need to Lumi Studio's live iOS apps and returns editorially localized context, the purchase model, a guide link, and a direct App Store link for the matching storefront.

- Repository: https://github.com/alice51849/lumi-mcp (MIT)
- Official MCP Registry: `io.github.alice51849/lumi-app-finder`, latest 1.2.0
- Image used in this entry: `ghcr.io/alice51849/lumi-app-finder:1.2.0` (public, multi-arch; `ENTRYPOINT ["/nodejs/bin/node"]`, `CMD ["server/index.mjs"]`, stdio transport)
- No environment variables, account, API key, or network access. The catalog snapshot is bundled and digest-verified, and query text stays inside the local MCP process.

**Disclosure:** this is a first-party publisher catalog — Lumi Studio develops every listed app. Results are publisher-authored text relevance matches, not an independent ranking, review, or measured search volume. That disclosure is carried in the tool description and in every response.

No generated indexes or README files were touched.
