### PR TITLE
Add ParlayAPI MCP server (sports)

### DIFF
--- a/packages/sports/parlayapi-mcp.json
+++ b/packages/sports/parlayapi-mcp.json
@@ -1,0 +1,17 @@
+{
+  "type": "mcp-server",
+  "name": "ParlayAPI MCP",
+  "packageName": "parlayapi-mcp",
+  "description": "Sports betting odds, player props, and prediction-market data from 45+ sportsbooks and sources across 90+ sports, with verdict, parlay grading, best-bets, arbitrage, +EV, consensus, and middles tools. 9 of the 22 tools run keyless, including a signup tool that returns a free-tier API key.",
+  "url": "https://github.com/JacobiusMakes/parlay-api-mcp",
+  "readme": "https://github.com/JacobiusMakes/parlay-api-mcp#readme",
+  "runtime": "python",
+  "license": "MIT",
+  "env": {
+    "PARLAYAPI_KEY": {
+      "description": "ParlayAPI key. Optional: the server starts keyless with live-preview and signup tools, and the parlayapi_signup tool can create a free-tier key (1,000 credits/month, no card) at runtime.",
+      "required": false,
+      "secret": true
+    }
+  }
+}


### PR DESCRIPTION
Adds one JSON entry: `packages/sports/parlayapi-mcp.json`.

Disclosure: I am the founder of ParlayAPI, submitting our own server.

Per the contribution guide:

- One server, one file, no unrelated changes; root README and indexes untouched.
- Local entry with a verifiable public package: `parlayapi-mcp` on PyPI, latest 0.3.4, MIT: https://pypi.org/project/parlayapi-mcp/
- Runtime: python (stdio, Python 3.10+). Runs via `uvx parlayapi-mcp`.
- Repository: https://github.com/JacobiusMakes/parlay-api-mcp (public, MIT, docs in README)
- `PARLAYAPI_KEY` is optional and marked secret: the server starts keyless with live-preview and signup tools, and `parlayapi_signup` can provision a free-tier key (1,000 credits/month, no card) at runtime.
- Also listed in the official MCP Registry as `io.github.JacobiusMakes/parlayapi` (active, 0.3.4).

Server documentation: https://parlay-api.com/docs and https://parlay-api.com/for-agents
