### PR TITLE
Add BestPrice Shopping remote MCP server

### DIFF
--- a/packages/search-data-extraction/bestprice-shopping.json
+++ b/packages/search-data-extraction/bestprice-shopping.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "BestPrice Shopping",
+  "packageName": "@toolsdk-remote/bestprice-shopping",
+  "description": "Searches BestPrice.gr products, compares current merchant offers, and returns price history for the Greek market through an official read-only remote endpoint.",
+  "url": "https://github.com/TheBestCo/bestprice-mcp",
+  "readme": "https://github.com/TheBestCo/bestprice-mcp#readme",
+  "runtime": "node",
+  "logo": "https://www.bestprice.gr/images/logo.svg",
+  "author": "BestPrice.gr",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.bestprice.gr/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the official BestPrice.gr shopping MCP as a public Streamable HTTP server.\n\n- Remote endpoint: `https://mcp.bestprice.gr/mcp`\n- Authentication: none\n- Access: read-only\n- Capabilities: product search, current merchant-offer comparison, and price history\n- Official registry identity: `gr.bestprice/mcp`\n\nValidation: `node scripts/validate-registry.mjs --base upstream/main` passes with 0 errors and 0 warnings.