### PR TITLE
Add Merlonix MCP server (monitoring)

### DIFF
--- a/packages/uncategorized/merlonix.json
+++ b/packages/uncategorized/merlonix.json
@@ -1,15 +1,10 @@
 {
   "type": "mcp-server",
-  "name": "Merlonix",
-  "packageName": "merlonix-mcp",
+  "packageName": "@toolsdk-remote/merlonix",
   "description": "Website and infrastructure monitoring over MCP: live SSL/TLS, DNS and domain-registration (RDAP) health for any hostname, MCP server health checks (initialize handshake + tools list + A–F security posture), AI agent-readiness scoring, email-blacklist and broken-link checks, and live cloud-vendor status. 8 public tools, no auth.",
-  "readme": "https://merlonix.com/docs/mcp-server/",
   "url": "https://github.com/cmhenry79/merlonix-mcp",
   "runtime": "node",
-  "bin": "merlonix-mcp",
-  "binArgs": [],
-  "author": "Merlonix",
-  "env": {},
+  "license": "MIT",
   "remotes": [
     {
       "type": "streamable-http",

--- a/packages/uncategorized/merlonix.json
+++ b/packages/uncategorized/merlonix.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "Merlonix",
+  "packageName": "merlonix-mcp",
+  "description": "Website and infrastructure monitoring over MCP: live SSL/TLS, DNS and domain-registration (RDAP) health for any hostname, MCP server health checks (initialize handshake + tools list + A–F security posture), AI agent-readiness scoring, email-blacklist and broken-link checks, and live cloud-vendor status. 8 public tools, no auth.",
+  "readme": "https://merlonix.com/docs/mcp-server/",
+  "url": "https://github.com/cmhenry79/merlonix-mcp",
+  "runtime": "node",
+  "bin": "merlonix-mcp",
+  "binArgs": [],
+  "author": "Merlonix",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.merlonix.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `packages/uncategorized/merlonix.json` for **Merlonix**, a hosted remote MCP server (MIT) for website/infrastructure monitoring.

- Remote `streamable-http` endpoint `https://api.merlonix.com/mcp`; also runnable via `npx -y github:cmhenry79/merlonix-mcp` (bin `merlonix-mcp`).
- 8 public tools, no auth: `check_domain_health` (SSL/DNS/RDAP), `check_mcp_health` (handshake + tools/list + A–F security posture), `check_agent_readiness`, `check_email_blacklist`, `check_broken_links`, live cloud-vendor status.
- Repo https://github.com/cmhenry79/merlonix-mcp · docs https://merlonix.com/docs/mcp-server/ · official registry `com.merlonix/monitoring`.

Endpoint verified live this session.