### PR TITLE
Add VidWords YouTube remote MCP server

### DIFF
--- a/packages/search-data-extraction/vidwords-youtube.json
+++ b/packages/search-data-extraction/vidwords-youtube.json
@@ -1,0 +1,21 @@
+{
+  "type": "mcp-server",
+  "name": "VidWords YouTube",
+  "packageName": "@toolsdk-remote/vidwords-youtube",
+  "description": "Searches YouTube transcripts across a whole channel, reads captions, and analyses a video's frames, returning answers with citable timestamps.",
+  "url": "https://github.com/haljishi/vidwords-mcp",
+  "readme": "https://github.com/haljishi/vidwords-mcp#readme",
+  "runtime": "node",
+  "license": "MIT",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://vidwords.com/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": ["mcp"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What this adds

One file: `packages/search-data-extraction/vidwords-youtube.json` — a remote MCP server entry for VidWords YouTube.

Nothing else is touched: no README, no `indexes/`, no lockfile or workflow changes, per `docs/CONTRIBUTING.md`.

### Source

- Endpoint: `https://vidwords.com/mcp` — public HTTPS Streamable HTTP, live
- Repo / docs: https://github.com/haljishi/vidwords-mcp (MIT)
- Official MCP registry: `com.vidwords/youtube`, `status: active` — verify with
  `curl "https://registry.modelcontextprotocol.io/v0/servers?search=vidwords"`

### Against the remote rules

- `packageName` starts with `@toolsdk-remote/` and `remotes` is non-empty.
- No `key` defined.
- Endpoint is HTTPS, public, not localhost or a private network.
- `runtime` is `node`, not `remote`, as the guide requires for a hosted-only server.
- OAuth 2.1 is declared with the scope the server actually advertises. `scopes_supported: ["mcp"]` is verifiable at `https://vidwords.com/.well-known/oauth-authorization-server`, which also shows DCR (`registration_endpoint`) and PKCE (`code_challenge_methods_supported: ["S256"]`).

### Category

`search-data-extraction` — the server's flagship tool, `search_transcript`, takes a **list** of videos, so one call searches a whole channel's transcripts and returns clickable timestamp citations. The category already holds `anaisbetts-mcp-youtube`, so YouTube retrieval belongs here.

Nine tools total: `search_transcript`, `get_transcript`, `list_channel_videos`, `analyze_video`, `get_analysis`, `ask_video`, `list_watchlists`, `watchlist_activity`, `account`.

### Disclosure

I maintain VidWords. There is a free tier that needs no card, so the endpoint is usable without payment.
