### PR TITLE
feat: register SandBase CLI MCP server

### DIFF
--- a/packages/developer-tools/sandbase-cli.json
+++ b/packages/developer-tools/sandbase-cli.json
@@ -1,0 +1,13 @@
+{
+  "type": "mcp-server",
+  "name": "SandBase CLI",
+  "packageName": "@sandbaseai/cli",
+  "packageVersion": "0.1.14",
+  "description": "Secure local MCP bridge for AI clients to discover, inspect, and run models and APIs.",
+  "url": "https://github.com/sandbaseai/cli",
+  "readme": "https://github.com/sandbaseai/cli#readme",
+  "runtime": "node",
+  "license": "Apache-2.0",
+  "binArgs": ["connect"],
+  "env": {}
+}


### PR DESCRIPTION
## Summary
- Register the published `@sandbaseai/cli` MCP server in Developer Tools
- Pin the verified Apache-2.0 v0.1.14 npm package
- Provide canonical repository and README links

## Verification
- Package metadata: https://www.npmjs.com/package/@sandbaseai/cli
- Official MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.sandbaseai%2Fcli
- Focused JSON-only change; no generated indexes or dependencies modified