### PR TITLE
Add Wine Labs MCP server

### DIFF
--- a/packages/finance-fintech/wine-labs-mcp.json
+++ b/packages/finance-fintech/wine-labs-mcp.json
@@ -3,7 +3,7 @@
   "name": "Wine Labs MCP",
   "packageName": "@toolsdk-remote/wine-labs-mcp",
   "description": "Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows through the hosted Wine Labs service.",
-  "url": "https://github.com/imiraoui/winelabs-mcp",
+  "url": "https://winelabs.ai/agents",
   "readme": "https://github.com/imiraoui/winelabs-mcp#readme",
   "runtime": "python",
   "env": {},

--- a/packages/finance-fintech/wine-labs-mcp.json
+++ b/packages/finance-fintech/wine-labs-mcp.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "Wine Labs MCP",
+  "packageName": "@toolsdk-remote/wine-labs-mcp",
+  "description": "Fine-wine identity matching, pricing, auction and exchange research, merchant comparisons, portfolios, and cellar workflows through the hosted Wine Labs service.",
+  "url": "https://github.com/imiraoui/winelabs-mcp",
+  "readme": "https://github.com/imiraoui/winelabs-mcp#readme",
+  "runtime": "python",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://chat.wine-labs.com/mcp",
+      "auth": {
+        "type": "oauth2",
+        "scopes": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a structured registry entry for the official Wine Labs hosted MCP server.
- Documents the Streamable HTTP endpoint and browser OAuth accurately.
- Links the canonical [Wine Labs MCP product page](https://winelabs.ai/agents) while retaining public connection metadata and installation documentation.

## Verification

- Public MCP endpoint returns the expected OAuth challenge.
- OAuth protected-resource discovery, product, install, privacy, and terms URLs return HTTP 200.
- `node scripts/validate-registry.mjs --base origin/main` passes with 0 errors and 0 warnings.

This is a maintainer self-submission prepared with an automated coding agent.