### PR TITLE
Add DC Hub to search-data-extraction

### DIFF
--- a/packages/search-data-extraction/dc-hub.json
+++ b/packages/search-data-extraction/dc-hub.json
@@ -1,0 +1,18 @@
+{
+  "type": "mcp-server",
+  "name": "DC Hub",
+  "packageName": "@toolsdk-remote/dc-hub",
+  "description": "Live data-center, power-grid, fiber and natural-gas infrastructure intelligence for site selection - facility and market lookups, grid capacity and interconnection queues, energy prices, and market scoring, with a provenance stamp on every response.",
+  "readme": "https://github.com/azmartone67/dchub-mcp-server#readme",
+  "url": "https://github.com/azmartone67/dchub-mcp-server",
+  "runtime": "node",
+  "license": "unknown",
+  "author": "azmartone67",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://dchub.cloud/mcp"
+    }
+  ]
+}

--- a/packages/search-data-extraction/dc-hub.json
+++ b/packages/search-data-extraction/dc-hub.json
@@ -6,7 +6,7 @@
   "readme": "https://github.com/azmartone67/dchub-mcp-server#readme",
   "url": "https://github.com/azmartone67/dchub-mcp-server",
   "runtime": "node",
-  "license": "unknown",
+  "license": "MIT",
   "author": "azmartone67",
   "env": {},
   "remotes": [


### PR DESCRIPTION
Adds one registry entry: `packages/search-data-extraction/dc-hub.json`.

DC Hub is a **remote** MCP server for the physical infrastructure behind AI
compute — data-center facilities, power-grid capacity and interconnection
queues, energy prices, fiber routes and natural-gas assets — used for site
selection and infrastructure research.

**Official endpoint:** `https://dchub.cloud/mcp` — public Streamable HTTP,
verified live:

```
$ curl -s -o /dev/null -w '%{http_code} %{content_type}\n' -X POST https://dchub.cloud/mcp \
    -H 'Content-Type: application/json' \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{...}}'
200 text/event-stream
```

- **Repo / docs:** https://github.com/azmartone67/dchub-mcp-server
- The free tier needs no key, so the endpoint is reachable for validation.
- `license` is set to `unknown` (matching the convention used by other entries)
  because the repository does not currently publish a LICENSE file — I did not
  want to assert one that isn't there.
- Category: `search-data-extraction`, alongside the other domain data-query
  servers (academic paper search, economics journals) rather than
  `data-platforms`, which is pipeline/warehouse oriented.

Per CONTRIBUTING: one server, one JSON file, placed directly in the category
directory, lowercase kebab-case filename. No README, index, workflow, lockfile
or dependency changes are included.