### PR TITLE
Add SandBase Harness MCP bridge

### DIFF
--- a/packages/coding-agents/sandbase-harness.json
+++ b/packages/coding-agents/sandbase-harness.json
@@ -1,0 +1,33 @@
+{
+  "type": "mcp-server",
+  "name": "SandBase Harness MCP Bridge",
+  "packageName": "ghcr.io/sandbaseai/sandbase-harness-mcp",
+  "description": "Local-first, self-hosted MCP bridge for SandBase Harness agent sessions, sandboxed execution, artifacts, approvals, audit, and replay.",
+  "url": "https://github.com/sandbaseai/sandbase-harness",
+  "readme": "https://github.com/sandbaseai/sandbase-harness/blob/main/llms-install.md",
+  "runtime": "docker",
+  "license": "Apache-2.0",
+  "author": "sandbaseai",
+  "packageVersion": "0.3.8",
+  "binArgs": [
+    "run",
+    "--rm",
+    "-i",
+    "-e",
+    "MANAGED_AGENTS_URL",
+    "-e",
+    "MANAGED_AGENTS_API_KEY",
+    "ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8"
+  ],
+  "env": {
+    "MANAGED_AGENTS_URL": {
+      "description": "Base URL of the connected SandBase Harness API.",
+      "required": true
+    },
+    "MANAGED_AGENTS_API_KEY": {
+      "description": "Optional API key for the connected Harness deployment.",
+      "required": false,
+      "secret": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add SandBase Harness as a Docker-backed MCP server entry.
- Pin the public v0.3.8 GHCR image and document the official installation guide.
- Expose the required Harness URL and optional API key configuration.

## Verification

- `node scripts/validate-registry.mjs --base origin/main` passes with 1 changed package and 0 errors.
- Image: https://github.com/orgs/sandbaseai/packages/container/package/sandbase-harness-mcp
- Source: https://github.com/sandbaseai/sandbase-harness
- The image has been independently verified with MCP `initialize` and `tools/list`, returning all six bridge tools.

This PR changes only one package JSON file.
