### PR TITLE
Add Process Street MCP Server

### DIFF
--- a/packages/other-tools-and-integrations/process-street-mcp.json
+++ b/packages/other-tools-and-integrations/process-street-mcp.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "Process Street MCP Server",
+  "packageName": "@toolsdk-remote/process-street-mcp",
+  "description": "Connect AI agents to Process Street workflows, tasks, runs, data sets, and operational records.",
+  "readme": "https://www.process.st/help/docs/mcp-server/",
+  "url": "https://github.com/process-street/process-street-mcp",
+  "runtime": "node",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.process.st/",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Process Street's official hosted Streamable HTTP MCP server.

## Verification

- Official public repository: https://github.com/process-street/process-street-mcp
- Documentation: https://www.process.st/help/docs/mcp-server/
- Hosted endpoint: https://mcp.process.st/
- An unauthenticated MCP initialize request returns the endpoint's OAuth protected-resource challenge
- The public source does not publish a license, so no license value is asserted
- `node scripts/validate-registry.mjs --base origin/main` passed with zero errors and zero warnings
- Confirmed no existing Process Street entry, issue, or pull request before preparing this change
