### PR TITLE
Add You.com remote MCP server

### DIFF
--- a/packages/search-data-extraction/youcom.json
+++ b/packages/search-data-extraction/youcom.json
@@ -1,0 +1,20 @@
+{
+  "type": "mcp-server",
+  "name": "You.com MCP",
+  "packageName": "@toolsdk-remote/youcom",
+  "description": "You.com hosted MCP endpoint providing current web and news search (you-search) with domain, country, language, and freshness filters, plus URL content extraction, cited research, and finance tools on the authenticated profile. OAuth is required for the full tool set; a keyless basic web-search profile is available at https://api.you.com/mcp?profile=free.",
+  "readme": "https://you.com/docs",
+  "url": "https://you.com/docs",
+  "runtime": "node",
+  "license": "unknown",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.you.com/mcp",
+      "auth": {
+        "type": "oauth2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds the You.com hosted MCP endpoint as a remote server under `search-data-extraction`.

You.com runs a public Streamable HTTP MCP endpoint at `https://api.you.com/mcp` (docs: https://you.com/docs). The endpoint serves current web and news search (`you-search`, with domain, country, language, and freshness filters) plus URL content extraction, cited research, and finance tools. OAuth is required for the full tool set — an unauthenticated `initialize` returns 401 with an OAuth-required response, so the entry follows the remote OAuth2 schema, matching the shape used by the GitHub remote entry.

For the unauthenticated subset, You.com also exposes a keyless basic web-search profile at `https://api.you.com/mcp?profile=free` (serves the `you-search` tool only); that limitation is noted in the description rather than modeled as a second remote, since one entry per server identity is cleaner. Happy to drop that sentence or reshape the entry if you'd prefer.

I placed it in `search-data-extraction` alongside Brave, Tavily, Exa, Kagi, and the DuckDuckGo servers, since it covers the same web-search + retrieval space.

Validation: `node scripts/validate-registry.mjs --base origin/main` passes (1 file, 0 errors, 0 warnings). Endpoint verified live: keyless profile `initialize`/`tools/list` returns 200 with the `you-search` tool; the main endpoint returns 401 without OAuth.

The PR touches only the new `packages/search-data-extraction/youcom.json` — no generated index or README changes, per the contributing guide.