### PR TITLE
chore: update OpenPost domain

### DIFF
--- a/packages/marketing/openpost.json
+++ b/packages/marketing/openpost.json
@@ -4,14 +4,14 @@
   "packageName": "@toolsdk-remote/openpost",
   "description": "Open-source social publishing and scheduling with an authenticated MCP server for preparing destination-specific content, reusing media, validating, scheduling, publishing, and inspecting delivery status.",
   "url": "https://github.com/getopenpost/openpost",
-  "readme": "https://docs.openpost.social/mcp/",
+  "readme": "https://docs.openpo.st/mcp/",
   "runtime": "docker",
   "license": "AGPL-3.0-only",
   "env": {},
   "remotes": [
     {
       "type": "streamable-http",
-      "url": "https://app.openpost.social/mcp",
+      "url": "https://app.openpo.st/mcp",
       "auth": {
         "type": "oauth2"
       }


### PR DESCRIPTION
OpenPost has moved from `openpost.social` to `openpo.st`. This updates the current listing to the canonical website and, where present, the matching docs and MCP endpoints.

The former hosts now only redirect to their `openpo.st` replacements.