### PR TITLE
Add Aperture Wallet Knowledge remote server

### DIFF
--- a/packages/finance-fintech/aperture-wallet-knowledge.json
+++ b/packages/finance-fintech/aperture-wallet-knowledge.json
@@ -1,0 +1,19 @@
+{
+  "type": "mcp-server",
+  "name": "Aperture Wallet Knowledge",
+  "packageName": "@toolsdk-remote/aperture-wallet-knowledge",
+  "description": "Read-only, citation-ready knowledge for Aperture Wallet product facts, self-custody security, supported mainnets, releases, app screens, and Journal articles. The 12 tools cannot connect to wallets, access secrets, sign, broadcast, or change state.",
+  "url": "https://github.com/devdasx/aperture",
+  "readme": "https://github.com/devdasx/aperture/blob/main/llms-install.md",
+  "logo": "https://aperturex.io/assets/favicon-32.png",
+  "runtime": "node",
+  "license": "MIT",
+  "author": "Aperture",
+  "env": {},
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://aperturex.io/mcp/"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the official Aperture Wallet Knowledge hosted MCP server to the Finance & Fintech category.

- Source: https://github.com/devdasx/aperture
- Documentation: https://github.com/devdasx/aperture/blob/main/llms-install.md
- Remote: https://aperturex.io/mcp/
- Transport: Streamable HTTP
- Authentication: none
- License: MIT
- Official Registry identity: `io.aperturex/aperture-wallet-knowledge`

The server exposes 12 read-only, citation-ready knowledge tools for Aperture Wallet product facts, self-custody security, supported mainnets, releases, app screens, and Journal articles. It cannot connect to a wallet, access secrets, sign, broadcast, or change state.

## Validation

- [x] One intended package JSON file only
- [x] New `@toolsdk-remote/` identity
- [x] Public HTTPS Streamable HTTP endpoint
- [x] No environment variables or credentials
- [x] `node scripts/validate-registry.mjs --base origin/main` — 0 errors, 0 warnings
- [x] Live initialization, tool discovery, and all 12 tool calls preflighted successfully