### PR TITLE
fix(registry): resolve GoodMemory CLI from its package manifest

### DIFF
--- a/packages/knowledge-memory/goodmemory.json
+++ b/packages/knowledge-memory/goodmemory.json
@@ -7,8 +7,7 @@
   "url": "https://github.com/hjqcan/GoodMemory",
   "readme": "https://github.com/hjqcan/GoodMemory/blob/v0.7.2/docs/GoodMemory-Standalone-MCP-Setup-Guide.md",
   "runtime": "node",
-  "bin": "scripts/goodmemory-mcp.js",
-  "binArgs": ["--standalone"],
+  "binArgs": ["mcp", "serve", "--standalone"],
   "license": "MIT",
   "env": {
     "GOODMEMORY_USER_ID": {


### PR DESCRIPTION
## Summary

Follow up on #440 by removing the remaining cwd-relative `bin` override. I maintain GoodMemory; the earlier correction incorrectly assumed this field was resolved relative to the npm package.

`getNodeMcpClient()` constructs an absolute path from the installed package's first `bin`, but a configured `bin` replaces that path verbatim. The current `scripts/goodmemory-mcp.js` therefore refers to the registry process's working directory, not `node_modules/goodmemory`. There is no such script in the registry root.

This change omits `bin` and adds `mcp serve` to `binArgs`. The published [goodmemory@0.7.2 manifest](https://registry.npmjs.org/goodmemory/0.7.2) lists `scripts/goodmemory-cli.js` first; that Node-compatible wrapper dispatches the documented `mcp serve --standalone` command to Bun. The existing package version, Node/Bun prerequisites, read-only default, and user-scope requirement are unchanged.

## Verification

- Trusted base: `5b570d4574aeff2773922f605bf1e074a6f0c59c`.
- Confirmed the existing relative script is absent from the registry root (`node --check scripts/goodmemory-mcp.js` reports `MODULE_NOT_FOUND`; no package was executed).
- `npm view goodmemory@0.7.2 bin engines --json` agrees with the tagged wrapper and CLI source.
- Trusted-main validator against the change: 1 package JSON, 0 errors, 0 warnings.
- Trusted-main whole-tree validator: 4,944 package JSON files, 0 errors, 0 warnings.
- `git diff --check` passes; only `packages/knowledge-memory/goodmemory.json` changes.

Per the registry review policy, no submitted MCP package was installed or executed. These are metadata/source-path checks, **not** a hosted runtime or end-to-end MCP claim. Bun must still be available to the executor; this PR does not provision it or resolve that remaining part of #439.
